### PR TITLE
Fix repository type

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.9",
   "author": "muji <noop@xpm.io>",
   "repository": {
-    "type": "https",
+    "type": "git",
     "url": "https://github.com/freeformsystems/async-validate.git"
   },
   "keywords": ["validation","validate","valid","object"],


### PR DESCRIPTION
@freeformsystems Sorry, wrongly changed the repo type from `git` to `https` in my previous fix. This is to revert the repo type back to `git`.
